### PR TITLE
Add "screensaver like" functionality

### DIFF
--- a/components/menu/include/menu.h
+++ b/components/menu/include/menu.h
@@ -28,7 +28,8 @@
  */
 typedef enum {
 	S_NORMAL = 0,
-    S_SETTINGS
+    S_SETTINGS,
+    S_SCREENSAVER
 	
 } deepdeck_status_t;
 

--- a/main/deepdeck_tasks.h
+++ b/main/deepdeck_tasks.h
@@ -70,10 +70,17 @@ void encoder_report(void *pvParameters);
 
 
 /**
- * @brief Tasks that hanlde deep sleep mode
+ * @brief Tasks that handles deep sleep mode
  * 
  * @param pvParameters 
  */
 void deep_sleep(void *pvParameters);
+
+/**
+ * @brief Tasks that handles screensaer mode
+ * 
+ * @param pvParameters 
+ */
+void screensaver(void *pvParameters);
 
 #endif

--- a/main/keyboard_config.h
+++ b/main/keyboard_config.h
@@ -88,6 +88,8 @@
 //deep sleep parameters, mind that reconnecting after deep sleep might take a minute or two
 //#define SLEEP_MINS 50 // undefine if you do not need deep sleep, otherwise define number of minutes for deepsleep
 
+// for screensaver
+#define SCREENSAVER_MINS 1
 
 
 /*
@@ -154,6 +156,7 @@ extern TaskHandle_t xKeyreportTask;
 
 #define MEM_WIFI_TASK				1024*4
 #define MEM_SLEEP_TASK				1024*4
+#define MEM_SCREENSAVER_TASK		1024*4
 #define	MEM_BATTERY_TASK			1024*4
 #define MEM_KEYBOARD_TASK			1024*8
 #define	MEM_LEDS_TASK				1024*4
@@ -170,6 +173,7 @@ extern TaskHandle_t xKeyreportTask;
 #define PRIOR_ENCODER_TASK			4
 #define PRIOR_OLED_TASK				3
 #define PRIOR_GESTURE_TASK			4
+#define PRIOR_SCREENSAVER_TASK		6
 
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -246,6 +246,11 @@ user_i2c_mutex = xSemaphoreCreateMutex();
 	ESP_LOGI("Sleep", "initialized");
 #endif
 
+#ifdef SCREENSAVER_MINS
+	xTaskCreate(screensaver, "screensaver task", MEM_SCREENSAVER_TASK, NULL, PRIOR_SCREENSAVER_TASK, NULL);
+	ESP_LOGI("Screensaver", "initialized");
+#endif
+
 #ifdef WIFI_ENABLE
 	// spiffs_init();
 	esp_log_level_set("Wifi", ESP_LOG_DEBUG);


### PR DESCRIPTION
This change adds a task that runs every minute (hopefully configurable soon) and turns the screen off if no key press was registered in that time. When you press a key (no rotary/gesture support yet) the screen will wake up. 

There are various areas I'd like to improve, but this should help keep any burn in to a minimum :). 

Initially I was looking at adding an animation to the screen but everything I read about OLED's said that a screensaver like that does not prevent burn in. 